### PR TITLE
Rototill to move to using lib_standard_app's io model

### DIFF
--- a/app/src/app_main.c
+++ b/app/src/app_main.c
@@ -34,17 +34,18 @@ void app_exit(void) {
   os_sched_exit(-1);
 }
 
-static uint8_t dispatch(command_t *cmd) {
+static void dispatch(command_t *cmd) {
   tz_handler_t f;
+  TZ_PREAMBLE(("cmd=0x%p {cla=0x02x ins=%u ...}", cmd, cmd->cla, cmd->ins));
 
-  FUNC_ENTER(("cmd=0x%p ins=%u", cmd, cmd->ins));
   if (cmd->cla != CLA)
-    THROW(EXC_CLASS);
+    TZ_FAIL(EXC_CLASS);
 
   switch (tz_ui_stream_get_type()) {
   case SCREEN_QUIT:
     PRINTF("[ERROR] received instruction whilst on Quit screen\n");
-    THROW(EXC_UNEXPECTED_STATE);
+    TZ_FAIL(EXC_UNEXPECTED_STATE);
+    break;
   default:
     break;
   }
@@ -67,17 +68,18 @@ static uint8_t dispatch(command_t *cmd) {
   case INS_SIGN_UNSAFE:               f = handle_unimplemented;       break;
   default:
     PRINTF("[ERROR] invalid instruction 0x%02x\n", cmd->ins);
-    THROW(EXC_INVALID_INS);
+    TZ_FAIL(EXC_INVALID_INS);
   }
 
-  uint8_t ret = f(cmd);
-  FUNC_LEAVE();
-  return ret;
+  TZ_CHECK(f(cmd));
+
+  TZ_POSTAMBLE;
 }
 
 
 void app_main() {
     command_t cmd;
+    int rx;
 
     FUNC_ENTER(("void"));
     app_stack_canary = 0xDEADBEEF;
@@ -109,61 +111,23 @@ void app_main() {
     PRINTF("[PTR]    G_io_app: 0x%p\n", &G_io_app);
     PRINTF("[SIZEOF] G_io_app: %d\n", sizeof(G_io_app));
 
-    global.step = ST_IDLE;
-    ui_home_init();
+    /* ST_ERROR implies that we are completely unknown and need to reset */
+    global.step = ST_ERROR;
 
-    volatile size_t rx = io_exchange(CHANNEL_APDU, 0);
-
-    while (true) {
-
-        BEGIN_TRY {
-            TRY {
-                PRINTF("[DEBUG] recv(0x%.*H)\n", rx, G_io_apdu_buffer);
-                if (rx == 0) {
-                    // no apdu received, well, reset the session, and reset the
-                    // bootloader configuration
-                    THROW(EXC_SECURITY);
-                }
-
-		if (!apdu_parser(&cmd, G_io_apdu_buffer, rx)) {
-		    PRINTF("[ERROR] Bad length: %u\n", rx);
-                    THROW(EXC_WRONG_LENGTH);
-		}
-
-                size_t const tx = dispatch(&cmd);
-
-                rx = io_exchange(CHANNEL_APDU, tx);
-            }
-            CATCH(ASYNC_EXCEPTION) {
-                rx = io_exchange(CHANNEL_APDU | IO_ASYNCH_REPLY, 0);
-            }
-            CATCH(EXCEPTION_IO_RESET) {
-                THROW(EXCEPTION_IO_RESET);
-            }
-            CATCH_OTHER(e) {
-                global.step = ST_IDLE;
-
-                uint16_t sw = e;
-                PRINTF("[ERROR] caught at top level, number: %x\n", sw);
-                switch (sw) {
-                    default:
-                        sw = 0x6800 | (e & 0x7FF);
-                        __attribute__((fallthrough));
-                    case 0x6000 ... 0x6FFF:
-                        __attribute__((fallthrough));
-                    case 0x9000 ... 0x9FFF: {
-                        PRINTF("[ERROR] line number: %d\n", sw & 0x0FFF);
-                        size_t tx = 0;
-                        G_io_apdu_buffer[tx++] = sw >> 8;
-                        G_io_apdu_buffer[tx++] = sw;
-                        rx = io_exchange(CHANNEL_APDU, tx);
-                        break;
-                    }
-                }
-            }
-            FINALLY {
-            }
+    for (;;) {
+        if (global.step == ST_ERROR) {
+            global.step = ST_IDLE;
+            ui_home_init();
         }
-        END_TRY;
+
+        PRINTF("Ready to receive a command packet.\n");
+        rx = io_recv_command();
+
+        if (!apdu_parser(&cmd, G_io_apdu_buffer, rx)) {
+            PRINTF("[ERROR] Bad length: %d\n", rx);
+            return;
+        }
+
+        dispatch(&cmd);
     }
 }

--- a/app/src/compat.h
+++ b/app/src/compat.h
@@ -1,0 +1,25 @@
+/*
+ * XXXrcd: Delete this file before the next release.
+ * XXXrcd: Delete this file when its incorporated upstream:
+ *         https://github.com/LedgerHQ/ledger-secure-sdk/pull/424
+ *         it needs to be cherry-picked onto a fork for each arch
+ *         so, it should take a couple of weeks
+ *         NOTE: this function ignores the offsets because we aren't
+ *               using them and we expect to delete this code very
+ *               soon...
+ */
+
+#include <io.h>
+
+static inline int io_send_response_buffers(const buffer_t *rdatalist,
+                                           size_t count, uint16_t sw)
+{
+  uint8_t buf[128];
+  size_t  tx = 0;
+
+  for (size_t i=0; i < count; i++) {
+    memcpy(&buf[tx], rdatalist[i].ptr, rdatalist[i].size);
+    tx += rdatalist[i].size;
+  }
+  return io_send_response_pointer(buf, tx, sw);
+}

--- a/app/src/globals.h
+++ b/app/src/globals.h
@@ -61,7 +61,8 @@ typedef enum {
   ST_IDLE,
   ST_CLEAR_SIGN,
   ST_BLIND_SIGN,
-  ST_PROMPT
+  ST_PROMPT,
+  ST_ERROR
 } main_step_t;
 
 typedef struct {

--- a/app/src/keys.c
+++ b/app/src/keys.c
@@ -26,8 +26,10 @@
 
 #include <buffer.h>
 #include <crypto_helpers.h>
+#include <io.h>
 
 #include "apdu.h"
+#include "exception.h"
 #include "keys.h"
 #include "globals.h"
 
@@ -46,30 +48,23 @@ static cx_curve_t derivation_type_to_cx_curve(derivation_type_t const
   }
 }
 
-cx_err_t read_bip32_path(bip32_path_t *const out, uint8_t const *const in,
-                         size_t in_size) {
+void read_bip32_path(bip32_path_t *const out, uint8_t const *const in,
+                     size_t in_size) {
     buffer_t cdata = {in, in_size, 0};
-    cx_err_t ret = CX_OK;
+    TZ_PREAMBLE(("out=%p, in=%p, in_size=%u", out, in, in_size));
 
-    FUNC_ENTER(("out=%p, in=%p, in_size=%u", out, in, in_size));
-
-    if(!buffer_read_u8(&cdata, &out->length) ||
-       !buffer_read_bip32_path(&cdata, (uint32_t *) &out->components,
-                               out->length)) {
-      ret = EXC_WRONG_LENGTH_FOR_INS;
-    }
-
-    FUNC_LEAVE();
-    return ret;
+    TZ_ASSERT(EXC_WRONG_LENGTH_FOR_INS,
+              buffer_read_u8(&cdata, &out->length) &&
+              buffer_read_bip32_path(&cdata, (uint32_t *) &out->components,
+                                     out->length));
+    TZ_POSTAMBLE;
 }
 
-cx_err_t generate_public_key(cx_ecfp_public_key_t *public_key,
-                             derivation_type_t const derivation_type,
-                             bip32_path_t const *const bip32_path) {
-    cx_err_t error = CX_OK;
-
-    FUNC_ENTER(("public_key=%p, derivation_type=%d, bip32_path=%p",
-                public_key, derivation_type, bip32_path));
+void generate_public_key(cx_ecfp_public_key_t *public_key,
+                         derivation_type_t const derivation_type,
+                         bip32_path_t const *const bip32_path) {
+    TZ_PREAMBLE(("public_key=%p, derivation_type=%d, bip32_path=%p",
+                 public_key, derivation_type, bip32_path));
 
     public_key->W_len = 65;
     public_key->curve = derivation_type_to_cx_curve(derivation_type);
@@ -94,27 +89,23 @@ cx_err_t generate_public_key(cx_ecfp_public_key_t *public_key,
         public_key->W_len = 33;
     }
 
-end:
-    FUNC_LEAVE();
-    return error;
+    TZ_POSTAMBLE;
 }
 
 #define HASH_SIZE 20
 
-cx_err_t public_key_hash(uint8_t *hash_out, size_t hash_out_size,
-                         cx_ecfp_public_key_t *compressed_out,
-                         derivation_type_t derivation_type,
-                         const cx_ecfp_public_key_t *public_key) {
-    cx_err_t error = CX_OK;
+void public_key_hash(uint8_t *hash_out, size_t hash_out_size,
+                     cx_ecfp_public_key_t *compressed_out,
+                     derivation_type_t derivation_type,
+                     const cx_ecfp_public_key_t *public_key) {
+    TZ_PREAMBLE(("hash_out=%p, hash_out_size=%u, compressed_out=%p, "
+                 "derivation_type=%d, public_key=%p",
+                 hash_out, hash_out_size, compressed_out,
+                 derivation_type, public_key));
 
-    FUNC_ENTER(("hash_out=%p, hash_out_size=%u, compressed_out=%p, "
-                "derivation_type=%d, public_key=%p",
-                hash_out, hash_out_size, compressed_out,
-                derivation_type, public_key));
-    check_null(hash_out);
-    check_null(public_key);
-    if (hash_out_size < HASH_SIZE) 
-        return EXC_WRONG_LENGTH;
+    TZ_ASSERT_NOTNULL(hash_out);
+    TZ_ASSERT_NOTNULL(public_key);
+    TZ_ASSERT(EXC_WRONG_LENGTH, hash_out_size >= HASH_SIZE);
 
     cx_ecfp_public_key_t compressed = {0};
     switch (derivation_type) {
@@ -132,7 +123,7 @@ cx_err_t public_key_hash(uint8_t *hash_out, size_t hash_out_size,
             break;
         }
         default:
-            return EXC_WRONG_PARAM;
+            TZ_FAIL(EXC_WRONG_PARAM);
     }
 
     cx_blake2b_t hash_state;
@@ -147,27 +138,23 @@ cx_err_t public_key_hash(uint8_t *hash_out, size_t hash_out_size,
         memmove(compressed_out, &compressed, sizeof(*compressed_out));
     }
 
-end:
-    FUNC_LEAVE();
-    return error;
+    TZ_POSTAMBLE;
 }
 
-cx_err_t sign(derivation_type_t derivation_type,
-              const bip32_path_t *path,
-              const uint8_t *hash, size_t hashlen,
-              uint8_t *sig, size_t *siglen) {
+void sign(derivation_type_t derivation_type,
+          const bip32_path_t *path,
+          const uint8_t *hash, size_t hashlen,
+          uint8_t *sig, size_t *siglen) {
     unsigned derivation_mode;
     uint32_t info;
     cx_curve_t curve = derivation_type_to_cx_curve(derivation_type);
-    cx_err_t err = EXC_WRONG_PARAM;
-
-    check_null(hash);
-    check_null(path);
-    check_null(sig);
-    check_null(siglen);
-    FUNC_ENTER(("sig=%p, siglen=%u, derivation_type=%d, "
-                "path=%p, hash=%p, hashlen=%u",
-                sig, *siglen, derivation_type, path, hash, hashlen));
+    TZ_PREAMBLE(("sig=%p, siglen=%u, derivation_type=%d, "
+                 "path=%p, hash=%p, hashlen=%u",
+                 sig, *siglen, derivation_type, path, hash, hashlen));
+    TZ_ASSERT_NOTNULL(path);
+    TZ_ASSERT_NOTNULL(hash);
+    TZ_ASSERT_NOTNULL(sig);
+    TZ_ASSERT_NOTNULL(siglen);
 
     switch (derivation_type) {
     case DERIVATION_TYPE_BIP32_ED25519:
@@ -175,30 +162,30 @@ cx_err_t sign(derivation_type_t derivation_type,
         derivation_mode = HDW_NORMAL;
         if (derivation_type == DERIVATION_TYPE_ED25519)
             derivation_mode = HDW_ED25519_SLIP10;
-        err = bip32_derive_with_seed_eddsa_sign_hash_256(derivation_mode,
-                                                         curve,
-                                                         path->components,
-                                                         path->length,
-                                                         CX_SHA512,
-                                                         hash, hashlen,
-                                                         sig, siglen,
-                                                         NULL, 0);
+        CX_CHECK(bip32_derive_with_seed_eddsa_sign_hash_256(derivation_mode,
+                                                            curve,
+                                                            path->components,
+                                                            path->length,
+                                                            CX_SHA512,
+                                                            hash, hashlen,
+                                                            sig, siglen,
+                                                            NULL, 0));
         break;
     case DERIVATION_TYPE_SECP256K1:
     case DERIVATION_TYPE_SECP256R1:
-        err = bip32_derive_ecdsa_sign_hash_256(curve,
-                                               path->components, path->length,
-                                               CX_RND_RFC6979 | CX_LAST,
-                                               CX_SHA256,
-                                               hash, hashlen,
-                                               sig, siglen, &info);
+        CX_CHECK(bip32_derive_ecdsa_sign_hash_256(curve,
+                                                  path->components,
+                                                  path->length,
+                                                  CX_RND_RFC6979 | CX_LAST,
+                                                  CX_SHA256,
+                                                  hash, hashlen,
+                                                  sig, siglen, &info));
         if (info & CX_ECCINFO_PARITY_ODD)
             sig[0] |= 0x01;
         break;
     default:
+        TZ_FAIL(EXC_WRONG_VALUES);
         break;
     }
-
-    FUNC_LEAVE();
-    return err;
+    TZ_POSTAMBLE;
 }

--- a/app/src/keys.h
+++ b/app/src/keys.h
@@ -54,16 +54,14 @@ typedef struct {
     derivation_type_t derivation_type;
 } bip32_path_with_curve_t;
 
-cx_err_t read_bip32_path(bip32_path_t *, const uint8_t *, size_t);
-cx_err_t generate_public_key(cx_ecfp_public_key_t *, derivation_type_t,
-                             const bip32_path_t *);
-cx_err_t public_key_hash(uint8_t *, size_t, cx_ecfp_public_key_t *,
-                         derivation_type_t, const cx_ecfp_public_key_t *);
-cx_err_t sign(derivation_type_t, const bip32_path_t *, const uint8_t *, size_t,
-              uint8_t *, size_t *);
+void read_bip32_path(bip32_path_t *, const uint8_t *, size_t);
+void generate_public_key(cx_ecfp_public_key_t *, derivation_type_t,
+                         const bip32_path_t *);
+void public_key_hash(uint8_t *, size_t, cx_ecfp_public_key_t *,
+                     derivation_type_t, const cx_ecfp_public_key_t *);
+void sign(derivation_type_t, const bip32_path_t *, const uint8_t *, size_t,
+          uint8_t *, size_t *);
 
-static inline cx_err_t check_derivation_type(derivation_type_t code) {
-    if (code >= DERIVATION_TYPE_ED25519 && code < DERIVATION_TYPE_MAX)
-        return CX_OK;
-    return EXC_WRONG_PARAM;
+static inline bool check_derivation_type(derivation_type_t code) {
+    return (code >= DERIVATION_TYPE_ED25519 && code < DERIVATION_TYPE_MAX);
 }

--- a/app/src/ui_stream.c
+++ b/app/src/ui_stream.c
@@ -58,8 +58,10 @@ void tz_ui_stream_close() {
   tz_ui_stream_t *s = &global.stream;
 
   FUNC_ENTER(("void"));
-  if (s->full)
-    failwith("trying to close already closed stream display");
+  if (s->full) {
+    PRINTF("trying to close already closed stream display");
+    THROW(EXC_UNKNOWN);
+  }
   s->full = true;
   FUNC_LEAVE();
 }
@@ -119,7 +121,8 @@ size_t tz_ui_stream_pushl(tz_ui_cb_type_t type, const char *title,
 
   FUNC_ENTER(("title=%s, value=%s", title, value));
   if (s->full) {
-    failwith("trying to push in already closed stream display");
+    PRINTF("trying to push in already closed stream display");
+    THROW(EXC_UNKNOWN);
   }
 #ifdef TEZOS_DEBUG
   int prev_total = s->total;
@@ -353,7 +356,7 @@ void tz_ui_stream_start(void) {
   FUNC_LEAVE();
 }
 
-__attribute__((noreturn)) void tz_ui_stream() {
+void tz_ui_stream() {
   FUNC_ENTER(("void"));
 
 #ifdef HAVE_BAGL
@@ -363,6 +366,5 @@ __attribute__((noreturn)) void tz_ui_stream() {
 
   redisplay();
 #endif // HAVE_BAGL
-
-  THROW(ASYNC_EXCEPTION);
+  FUNC_LEAVE();
 }

--- a/app/src/ui_stream.h
+++ b/app/src/ui_stream.h
@@ -109,6 +109,6 @@ size_t tz_ui_stream_push_all(tz_ui_cb_type_t, const char *, const char *,
                              tz_ui_icon_t);
 void tz_ui_stream_push_accept_reject(void);
 void tz_ui_stream_close(void);
-__attribute__((noreturn)) void tz_ui_stream(void);
+void tz_ui_stream(void);
 void tz_ui_stream_start(void);
 tz_ui_cb_type_t tz_ui_stream_get_type(void);


### PR DESCRIPTION
This invovles getting rid of all of the setjmp(3)/longjmp(3) and percolating errors around in the more idiomatic C way.  We define a set of macros to make it all a little easier to keep track of.