### PR TITLE
app: store settings in NVM

### DIFF
--- a/app/src/globals.c
+++ b/app/src/globals.c
@@ -1,6 +1,7 @@
 /* Tezos Ledger application - Global application state
 
    Copyright 2023 Nomadic Labs <contact@nomadic-labs.com>
+   Copyright 2023 Trilitech <contact@trili.tech>
 
    With code excerpts from:
     - Legacy Tezos app, Copyright 2019 Obsidian Systems
@@ -25,9 +26,22 @@
 
 globals_t global;
 
+const settings_t N_settings_real;
+
 void init_globals(void) {
     memset(&global, 0, sizeof(global));
     memset(G_io_seproxyhal_spi_buffer, 0, sizeof(G_io_seproxyhal_spi_buffer));
     memset(&G_ux, 0, sizeof(G_ux));
     memset(&G_ux_params, 0, sizeof(G_ux_params));
+}
+
+void toggle_blindsigning(void) {
+    settings_t tmp;
+    memcpy(&tmp,
+           (void*) &N_settings,
+           sizeof(tmp));
+    tmp.blindsigning = !N_settings.blindsigning;
+    nvm_write((void*) &N_settings,
+              (void*) &tmp,
+              sizeof(N_settings));
 }

--- a/app/src/globals.h
+++ b/app/src/globals.h
@@ -47,6 +47,9 @@
 // UI/exchange buffers.
 void init_globals(void);
 
+// Toggles the persisted blindsigning setting
+void toggle_blindsigning(void);
+
 #define MAX_APDU_SIZE      235
 #define MAX_SIGNATURE_SIZE 100
 
@@ -65,11 +68,6 @@ typedef enum {
 } main_step_t;
 
 typedef struct {
-  /* Settings */
-  struct {
-    bool blindsigning;
-  } settings;
-
   /* State */
   main_step_t step;
   tz_ui_stream_t stream;
@@ -90,7 +88,15 @@ typedef struct {
 # endif
 } globals_t;
 
+/* Settings */
+typedef struct {
+  bool blindsigning;
+} settings_t;
+
 extern globals_t global;
+
+extern const settings_t N_settings_real;
+#define N_settings (*(volatile settings_t *) PIC(&N_settings_real))
 
 extern unsigned int app_stack_canary;  // From SDK
 

--- a/app/src/ui_home.c
+++ b/app/src/ui_home.c
@@ -1,6 +1,7 @@
 /* Tezos Ledger application - Home screen display
 
    Copyright 2023 Nomadic Labs <contact@nomadic-labs.com>
+   Copyright 2023 Trilitech <contact@trili.tech>
 
    With code excerpts from:
     - Legacy Tezos app, Copyright 2019 Obsidian Systems
@@ -73,7 +74,7 @@ void ui_home_init(void) {
 #ifdef HAVE_BAGL
   tz_ui_stream_init(cb);
   clear_sign_screen();
-  if (global.settings.blindsigning)
+  if (N_settings.blindsigning)
     blind_sign_screen();
   tz_ui_stream_push(SCREEN_SETTINGS, "Settings", "", TZ_UI_ICON_SETTINGS);
   tz_ui_stream_push(SCREEN_QUIT, "Quit?", "", TZ_UI_ICON_DASHBOARD);

--- a/app/src/ui_home_nbgl.c
+++ b/app/src/ui_home_nbgl.c
@@ -52,7 +52,7 @@ static bool navigation_cb_wallet(__attribute__((unused))uint8_t page,
   case 1:
     switches[0] =
       (nbgl_layoutSwitch_t)
-      {.initState = global.settings.blindsigning ? ON_STATE : OFF_STATE,
+      {.initState = N_settings.blindsigning ? ON_STATE : OFF_STATE,
        .text = "Blind signing",
        .subText = "Enable blindsigning",
        .token = BLIND_SIGNING_TOKEN,
@@ -73,8 +73,9 @@ static void controls_callback(int token,
                               __attribute__((unused))uint8_t index) {
   switch (token) {
   case BLIND_SIGNING_TOKEN:
-    global.settings.blindsigning = !global.settings.blindsigning;
-    if (!global.settings.blindsigning)
+    toggle_blindsigning();
+
+    if (!N_settings.blindsigning)
       global.home_screen = SCREEN_CLEAR_SIGN;
     break;
   }
@@ -101,7 +102,7 @@ static void ui_toggle_clear_blind(void) {
 void tz_ui_home_redisplay(void) {
   FUNC_ENTER(("void"));
 
-  if (!global.settings.blindsigning) {
+  if (!N_settings.blindsigning) {
     nbgl_useCaseHome("Tezos Wallet",
                      &C_tezos,
                      "Ready for signing",

--- a/app/src/ui_settings.c
+++ b/app/src/ui_settings.c
@@ -1,6 +1,23 @@
-/*
- *
- */
+/* Tezos Ledger application - Home screen display
+
+   Copyright 2023 TriliTech <contact@nomadic-labs.com>
+
+   With code excerpts from:
+    - Legacy Tezos app, Copyright 2019 Obsidian Systems
+    - Legacy Tezos app, Copyright 2023 Ledger
+    - Ledger Blue sample apps, Copyright 2016 Ledger
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
 
 #include "globals.h"
 
@@ -14,10 +31,9 @@ static void
 cb(tz_ui_cb_type_t type)
 {
   FUNC_ENTER(("type=%u\n", type));
-
   switch (type) {
   case BLIND_SIGNING:
-    global.settings.blindsigning = !global.settings.blindsigning;
+    toggle_blindsigning();
     ui_settings_init();
     break;
   case BACK:
@@ -33,7 +49,7 @@ ui_settings_init(void)
 
   FUNC_ENTER(("void"));
 
-  if (global.settings.blindsigning)
+  if (N_settings.blindsigning)
     bsigning = "ENABLED";
 
   tz_ui_stream_init(cb);


### PR DESCRIPTION
required to persist settings (currently just blindsiging toggle) between user-runs of the app.

# Testing

The following works with the inclusion of this PR:
- Run the app on a physical device (e.g. nanos)
- Open the app
- enable blindsigning
- exit the app
- Re-open the app. Blindsigning should still be enabled

To build & run the app on the nanos, connect & unlock the nanos, and then run:
```
docker run --rm -ti --user "$(id -u):$(id -g)" --privileged -v "/dev/bus/usb:/dev/bus/usb" -v "$(realpath .):/app" ghcr.io/ledgerhq/ledger-app-builder/ledger-app-dev-tools:latest

cd app
make load
```
and follow the prompts on the nanos