### PR TITLE
Fix formats

### DIFF
--- a/app/src/apdu_pubkey.c
+++ b/app/src/apdu_pubkey.c
@@ -109,7 +109,7 @@ stream_cb(tz_ui_cb_type_t type)
 static void
 prompt_address(void)
 {
-    char buf[TZ_UI_STREAM_CONTENTS_SIZE + 1];
+    char buf[TZ_BASE58CHECK_BUFFER_SIZE(20, 3)];
     TZ_PREAMBLE(("void"));
 
     global.step = ST_PROMPT;
@@ -154,7 +154,7 @@ confirmation_callback(bool confirm)
 static void
 verify_address(void)
 {
-    char buf[TZ_UI_STREAM_CONTENTS_SIZE + 1];
+    char buf[TZ_BASE58CHECK_BUFFER_SIZE(20, 3)];
     TZ_PREAMBLE(("void"));
 
     TZ_CHECK(format_pkh(buf));

--- a/app/src/apdu_sign.c
+++ b/app/src/apdu_sign.c
@@ -453,7 +453,8 @@ handle_data_apdu_blind(packet_t *pkt)
     global.apdu.sign.received_last_msg = true;
     global.apdu.sign.step              = SIGN_ST_WAIT_USER_INPUT;
 
-    tz_format_base58(FINAL_HASH, sizeof(FINAL_HASH), obuf);
+    if (tz_format_base58(FINAL_HASH, sizeof(FINAL_HASH), obuf, sizeof(obuf)))
+        TZ_FAIL(EXC_UNKNOWN);
 
     // clang-format off
     switch(global.apdu.sign.u.blind.tag) {

--- a/app/src/parser/formatting.h
+++ b/app/src/parser/formatting.h
@@ -192,13 +192,13 @@ typedef enum {
 // stored in little-endian order in the first `l` bytes of `n`. The
 // output buffer `obuf` must be at least `DECIMAL_BUFFER_SIZE(l)`
 // (caller responsibility).
-void tz_format_decimal(const uint8_t *, size_t, char *);
+int tz_format_decimal(const uint8_t *, size_t, char *, size_t);
 #define TZ_DECIMAL_BUFFER_SIZE(_l) ((_l)*241 / 100 + 1)
 
 // Formats a data `n` of size `l` in base58 using Tezos' alphabet
 // order (same as Bitcoin). The output buffer `obuf` must be at least
 // `BASE58_BUFFER_SIZE(l)` (caller responsibility).
-void tz_format_base58(const uint8_t *, size_t, char *);
+int tz_format_base58(const uint8_t *, size_t, char *, size_t);
 #define TZ_BASE58_BUFFER_SIZE(_l) ((_l)*138 / 100 + 1)
 
 // Looks up the prefix from the provided string (arg1), e.g. "B",
@@ -209,7 +209,8 @@ void tz_format_base58(const uint8_t *, size_t, char *);
 // double-sha256 of this concatenation, and call `format_base58`. The
 // output buffer `obuf` must be at least `BASE58CHECK_BUFFER_SIZE(l,
 // prefix_len)` (caller responsibility).
-int tz_format_base58check(const char *, const uint8_t *, size_t, char *);
+int tz_format_base58check(const char *, const uint8_t *, size_t, char *,
+                          size_t);
 #define TZ_BASE58CHECK_BUFFER_SIZE(_l, _p) \
     TZ_BASE58_BUFFER_SIZE((_p) + (_l) + 4)
 
@@ -224,13 +225,13 @@ int tz_format_base58check(const char *, const uint8_t *, size_t, char *);
 // tag 1: tz2(36)
 // tag 2: tz3(36)
 // tag 3: tz4(36)
-int tz_format_pkh(const uint8_t *, size_t, char *);
+int tz_format_pkh(const uint8_t *, size_t, char *, size_t);
 
 // size 32, o(51)
-int tz_format_oph(const uint8_t *, size_t, char *);
+int tz_format_oph(const uint8_t *, size_t, char *, size_t);
 
 // size 32, B(51)
-int tz_format_bh(const uint8_t *, size_t, char *);
+int tz_format_bh(const uint8_t *, size_t, char *, size_t);
 
 // size 22: tag(1) + data(21)
 // tag 0: tag(1) + pkh(20) (tz1, tz2, tz3, tz4, see format_pkh)
@@ -238,11 +239,11 @@ int tz_format_bh(const uint8_t *, size_t, char *);
 // tag 2: txrolluph(20) + padding(1), txr1(36)
 // tag 3: rolluph(20) + padding(1), scr1(36)
 // tag 4: zkrolluph(20) + padding(1), zkr1(36)
-int tz_format_address(const uint8_t *, size_t, char *);
+int tz_format_address(const uint8_t *, size_t, char *, size_t);
 
 // size 33/34/49: tag(1) + data(32/33/48)
 // tag 0: pk(32), edpk(54)
 // tag 1: pk(33), sppk(55)
 // tag 2: pk(33), p2pk(55)
 // tag 3: pk(48), BLpk(76)
-int tz_format_pk(const uint8_t *, size_t, char *);
+int tz_format_pk(const uint8_t *, size_t, char *, size_t);

--- a/app/src/parser/formatting.h
+++ b/app/src/parser/formatting.h
@@ -193,13 +193,13 @@ typedef enum {
 // output buffer `obuf` must be at least `DECIMAL_BUFFER_SIZE(l)`
 // (caller responsibility).
 void tz_format_decimal(const uint8_t *, size_t, char *);
-#define TZ_DECIMAL_BUFFER_SIZE(l) (l * 241 / 100 + 1)
+#define TZ_DECIMAL_BUFFER_SIZE(_l) ((_l)*241 / 100 + 1)
 
 // Formats a data `n` of size `l` in base58 using Tezos' alphabet
 // order (same as Bitcoin). The output buffer `obuf` must be at least
 // `BASE58_BUFFER_SIZE(l)` (caller responsibility).
 void tz_format_base58(const uint8_t *, size_t, char *);
-#define TZ_BASE58_BUFFER_SIZE(l) (l * 138 / 100 + 1)
+#define TZ_BASE58_BUFFER_SIZE(_l) ((_l)*138 / 100 + 1)
 
 // Looks up the prefix from the provided string (arg1), e.g. "B",
 // "o", "expr", "tz2", etc.  This indexes into a table which finds
@@ -210,7 +210,8 @@ void tz_format_base58(const uint8_t *, size_t, char *);
 // output buffer `obuf` must be at least `BASE58CHECK_BUFFER_SIZE(l,
 // prefix_len)` (caller responsibility).
 int tz_format_base58check(const char *, const uint8_t *, size_t, char *);
-#define TZ_BASE58CHECK_BUFFER_SIZE(l, p) TZ_BASE58_BUFFER_SIZE(p + l + 4)
+#define TZ_BASE58CHECK_BUFFER_SIZE(_l, _p) \
+    TZ_BASE58_BUFFER_SIZE((_p) + (_l) + 4)
 
 // Some Tezos-specific base58check formatters. These functions
 // deconstruct the Tezos binary header to figure out the kind within

--- a/app/src/parser/num_parser.c
+++ b/app/src/parser/num_parser.c
@@ -57,7 +57,7 @@ tz_parse_num_step(tz_num_parser_buffer *buffers, tz_num_parser_regs *regs,
     if (!cont) {
         regs->stop = true;
         tz_format_decimal(buffers->bytes, (regs->size + 7) / 8,
-                          buffers->decimal);
+                          buffers->decimal, sizeof(buffers->decimal));
     }
     return TZ_CONTINUE;
 }


### PR DESCRIPTION
We solve a buffer overflow here. In these commits, we:
- add an output buffer size parameter to most `tz_format_*()` functions. This allows us to fail if we are going to overflow any buffers. The current documentation in headers says that it is the caller's responsibility to ensure that the buffers are large enough to contain the formatted string, but without some sort of verification it is too easy to make an error. Now, we doublecheck,
- we fix some sizes that were actually incorrect, and
- the macro `TZ_BASE58CHECK_BUFFER_SIZE()` did not evaluate to the correct number, because the macro `TZ_BASE58_BUFFER_SIZE()`  did not put brackets to ensure that order of operations did not fail. As a drive by, I used `_` in front of each argument in the macros to make it less likely that the arguments conflict with variables in the existing namespace.