### PR TITLE
Stax: add a spinner on skip

### DIFF
--- a/app/src/ui_stream_nbgl.c
+++ b/app/src/ui_stream_nbgl.c
@@ -1,6 +1,7 @@
 /* Tezos Ledger application - Generic stream display
 
    Copyright 2023 Nomadic Labs <contact@nomadic-labs.com>
+   Copyright 2023 Functori <contact@functori.com>
    Copyright 2023 TriliTech <contact@trili.tech>
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -195,7 +196,15 @@ tz_ui_nav_cb(uint8_t page, nbgl_pageContent_t *content)
         tz_ui_continue();
     }
 
-    if (!s->full && !global.apdu.sign.u.clear.skip_to_sign) {
+    if (s->full) {
+        content->type                        = INFO_LONG_PRESS;
+        content->infoLongPress.icon          = &C_tezos;
+        content->infoLongPress.text          = "Sign";
+        content->infoLongPress.longPressText = "Sign";
+    } else if (page == LAST_PAGE_FOR_REVIEW) {
+        nbgl_useCaseSpinner("Loading operation");
+        return false;
+    } else {
         c->list.pairs             = NULL;
         c->list.callback          = tz_ui_current_screen;
         c->list.startIndex        = 0;
@@ -205,11 +214,6 @@ tz_ui_nav_cb(uint8_t page, nbgl_pageContent_t *content)
 
         content->type         = TAG_VALUE_LIST;
         content->tagValueList = c->list;
-    } else {
-        content->type                        = INFO_LONG_PRESS;
-        content->infoLongPress.icon          = &C_tezos;
-        content->infoLongPress.text          = "Sign";
-        content->infoLongPress.longPressText = "Sign";
     }
 
     FUNC_LEAVE();

--- a/tests/integration/stax/test_sign_execute_outbox_messages_skip.py
+++ b/tests/integration/stax/test_sign_execute_outbox_messages_skip.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# Copyright 2023 Functori <contact@functori.com>
 # Copyright 2023 Trilitech <contact@trili.tech>
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,7 +34,7 @@ if __name__ == "__main__":
     app.review.tap()
     app.assert_screen("operation_0_sr_outbox")
 
-    app.review_skip_to_signing()
+    app.review_skip_to_signing(with_loading=True)
 
     app.expect_apdu_return("9000")
     app.send_apdu("800f82004f63313162343430616334643334353564656462653465653064653135613861663632306434633836323437643964313332646531626236646132336435666639643864666664613232626139613834")

--- a/tests/integration/stax/utils.py
+++ b/tests/integration/stax/utils.py
@@ -1,3 +1,4 @@
+# Copyright 2023 Functori <contact@functori.com>
 # Copyright 2023 Trilitech <contact@trili.tech>
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -66,7 +67,7 @@ class TezosAppScreen(metaclass=MetaScreen):
         """Expect hex-encoded response from the apdu"""
         response = self.__backend.receive().raw
         expected = bytes.fromhex(expected)
-        assert response == expected, f"Expected {expected}, received {response}"
+        assert response == expected, f"Expected {expected.hex()}, received {response.hex()}"
 
     def expect_apdu_failure(self, code):
         """Expect failure of 'code'"""
@@ -123,10 +124,13 @@ class TezosAppScreen(metaclass=MetaScreen):
         self.review.tap()
         self.welcome.client.resume_ticker()
 
-    def review_skip_to_signing(self):
-        self.welcome.client.finger_touch(BUTTON_LOWER_RIGHT.x, BUTTON_LOWER_RIGHT.y)
+    def review_skip_to_signing(self, with_loading=False):
+        self.review.client.finger_touch(BUTTON_LOWER_RIGHT.x, BUTTON_LOWER_RIGHT.y)
         self.assert_screen("skip_to_signing")
-        self.welcome.client.finger_touch(BUTTON_ABOVE_LOWER_MIDDLE.x, BUTTON_ABOVE_LOWER_MIDDLE.y)
+        self.review.client.pause_ticker()
+        self.review.client.finger_touch(BUTTON_ABOVE_LOWER_MIDDLE.x, BUTTON_ABOVE_LOWER_MIDDLE.y)
+        if with_loading: self.assert_screen("loading_operation")
+        self.review.client.resume_ticker()
 
 def stax_app() -> TezosAppScreen:
     port = os.environ["PORT"]


### PR DESCRIPTION
Currently, after a skip during a signing request on stax, the user is able to sign even though all the apdus have not yet been received.
To avoid this, this MR adds a spinner until all the apdus have been received.