### PR TITLE
Re-enable nanox generated tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,8 +116,8 @@ jobs:
           mkdir -p tests/samples/micheline/nanosp
           mkdir -p tests/samples/operations/nanosp
 
-#          mkdir -p tests/samples/micheline/nanox
-#          mkdir -p tests/samples/operations/nanox
+          mkdir -p tests/samples/micheline/nanox
+          mkdir -p tests/samples/operations/nanox
 
       - name: Generate
         run: |
@@ -133,10 +133,10 @@ jobs:
           dune exec ./tests/generate/generate.exe operations 500 \
               nanosp tests/samples/operations \
 
-#          dune exec ./tests/generate/generate.exe micheline 500 \
-#              nanox tests/samples/micheline
-#          dune exec ./tests/generate/generate.exe operations 500 \
-#              nanox tests/samples/operations
+          dune exec ./tests/generate/generate.exe micheline 500 \
+              nanox tests/samples/micheline
+          dune exec ./tests/generate/generate.exe operations 500 \
+              nanox tests/samples/operations
 
       - name: Unit tests
         run: |
@@ -167,17 +167,17 @@ jobs:
           name: nanosp_samples_operations
           path: tests/samples/operations/nanosp
 
-#      - name: Upload results (nanox, micheline)
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: nanox_samples_micheline
-#          path: tests/samples/micheline/nanox
-#
-#      - name: Upload results (nanox, operations)
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: nanox_samples_operations
-#          path: tests/samples/operations/nanox
+      - name: Upload results (nanox, micheline)
+        uses: actions/upload-artifact@v3
+        with:
+          name: nanox_samples_micheline
+          path: tests/samples/micheline/nanox
+
+      - name: Upload results (nanox, operations)
+        uses: actions/upload-artifact@v3
+        with:
+          name: nanox_samples_operations
+          path: tests/samples/operations/nanox
 
   integration_tests_samples:
     needs: [build_app, generate_samples_unit_tests, build_docker_integration_tests]
@@ -185,7 +185,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        device: [nanos, nanosp]
+        device: [nanos, nanosp, nanox]
         type: [micheline, operations]
     container:
       image: ${{ needs.build_docker_integration_tests.outputs.image }}

--- a/tests/integration/check_section_text.py
+++ b/tests/integration/check_section_text.py
@@ -47,12 +47,11 @@ class Screen:
     content = content.lstrip('\n')
     return content
 
-def with_retry(url, f, timeout=TIMEOUT):
+def with_retry(f, timeout=TIMEOUT):
     attempts = timeout / 0.5
     while True:
         try:
-            on_screen = get_screen(url)
-            return f(on_screen)
+            return f()
         except AssertionError as e:
             print('- retrying:', e)
             if attempts <= 0:
@@ -89,14 +88,15 @@ def press_left(url):
 def check_multi_screen(url, title, content, content_lines, device):
     """Assert that the screen contents across all screens with the given title match expected content."""
     while True:
-      def check_screen(screen):
+      def check_screen():
+        screen = get_screen(url)
         assert screen.title == title, f"expected section '{title}' but on '{screen.title}'"
         assert screen.matches(content, content_lines), \
                f"{screen} did not match {content[:10]}...{content[-10:]}"
 
         return screen.strip(content)
 
-      content = with_retry(url, check_screen)
+      content = with_retry(check_screen)
 
       if content == "":
         break


### PR DESCRIPTION
fixes #43 
The `$URL/events?currentscreenonly=true` service does not seem to correspond to what is actually on the screen.
Fortunately, the `$URL/events` service allows the recovery of everything that has been displayed, including what has been lost by `$URL/events?currentscreenonly=true`.