### PR TITLE
tests: temporarily fix flaky pk tests

### DIFF
--- a/tests/integration/test_runtime.sh
+++ b/tests/integration/test_runtime.sh
@@ -264,10 +264,10 @@ run_a_test() {
                     ;;
                 *.py)
                     start_speculos "$seed"
-		    PORT=$PORT\
-			COMMIT_BYTES=$COMMIT_BYTES\
-			VERSION_BYTES=$VERSION_BYTES\
-			python3 $CMD
+                    PORT=$PORT\
+                        COMMIT_BYTES=$COMMIT_BYTES\
+                        VERSION_BYTES=$VERSION_BYTES\
+                        python3 $CMD
                     ;;
                 *.hex)
                     # We skip these...
@@ -439,7 +439,7 @@ main() {
     # Defaults:
     TARGET=nanos
     TEST_TRACE=0
-    export TIMEOUT=5
+    export TIMEOUT=10
     NUM_SPECULOS=32
 
     while getopts FT:l:m:n:t:x o; do


### PR DESCRIPTION
This is ultimately due to assuming `send_apdu` is synchronous, when in fact it runs in the background. This can lead to `expect_apdu_return` doing its check before the apdu call is complete, unless intermediate steps are in place