### PR TITLE
CI: run jobs on develop branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - main
+      - develop
   pull_request:
 
 jobs:

--- a/.github/workflows/codeql_checks.yml
+++ b/.github/workflows/codeql_checks.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
       - main
       - develop
   pull_request:

--- a/.github/workflows/coding_style_checks.yml
+++ b/.github/workflows/coding_style_checks.yml
@@ -10,7 +10,6 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
       - main
       - develop
   pull_request:

--- a/.github/workflows/guidelines_enforcer.yml
+++ b/.github/workflows/guidelines_enforcer.yml
@@ -12,7 +12,6 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
       - main
       - develop
   pull_request:

--- a/.github/workflows/swap.yml
+++ b/.github/workflows/swap.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
     - main
+    - develop
   pull_request:
 
 jobs:


### PR DESCRIPTION
We will use the `develop` branch for the bootstrapping of the baking app, to avoid churn while the wallet audit is happening

fixes #74 