### PR TITLE
Swap: Change branche pointer for commit pointer in swap job

### DIFF
--- a/.github/workflows/swap.yml
+++ b/.github/workflows/swap.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   job_functional_tests:
-    uses: spalmer25/app-exchange/.github/workflows/reusable_swap_functional_tests.yml@palmer/functori/add-new-tezos-app-swap-tests
+    uses: spalmer25/app-exchange/.github/workflows/reusable_swap_functional_tests.yml@987035363878dd55e9da2336891a666b36bce6a2
     with:
       repo_for_exchange: 'spalmer25/app-exchange'
       branch_for_exchange: 'palmer/functori/add-new-tezos-app-swap-tests'


### PR DESCRIPTION
In order to enable changes to be made to the `palmer/functori/add-new-tezos-app-swap-tests` branch of the `spalmer25/app-exchange` repository without breaking the tests.