### PR TITLE
wallet: Add public key to globals

### DIFF
--- a/app/src/app_main.c
+++ b/app/src/app_main.c
@@ -44,8 +44,10 @@ print_memory_layout(void)
     PRINTF("[PTR]    G_io_apdu_buffer: 0x%p\n", G_io_apdu_buffer);
     PRINTF("[PTR]    global: 0x%p\n", &global);
     PRINTF("[SIZEOF] global: %d\n", sizeof(global));
-    PRINTF("[SIZEOF] global.apdu.sign: %d\n", sizeof(global.apdu.sign));
-    PRINTF("[SIZEOF] global.apdu.hash: %d\n", sizeof(global.apdu.hash));
+    PRINTF("[SIZEOF] global.keys.apdu.sign: %d\n",
+           sizeof(global.keys.apdu.sign));
+    PRINTF("[SIZEOF] global.keys.apdu.hash: %d\n",
+           sizeof(global.keys.apdu.hash));
     PRINTF("[SIZEOF] global.stream: %d\n", sizeof(global.stream));
     PRINTF("[PTR]    G_io_apdu_buffer: 0x%p\n", G_io_apdu_buffer);
     PRINTF("[SIZEOF] G_io_apdu_buffer: %u\n", sizeof(G_io_apdu_buffer));

--- a/app/src/globals.h
+++ b/app/src/globals.h
@@ -74,10 +74,18 @@ typedef struct {
     main_step_t             step;
     tz_ui_stream_t          stream;
     bip32_path_with_curve_t path_with_curve;
-    struct {
-        apdu_hash_state_t hash;
-        apdu_sign_state_t sign;
-    } apdu;
+    union {
+        struct {
+            apdu_hash_state_t hash;
+            apdu_sign_state_t sign;
+        } apdu;
+        /** Warning: Use this pubkey only when apdu-hash/sign
+         * is not being used.
+         * Only being used in apdu_pubkey.c : handle_apdu_get_public_key
+         * currently.
+         * */
+        cx_ecfp_public_key_t pubkey;
+    } keys;
     char line_buf[TZ_UI_STREAM_CONTENTS_SIZE + 1];
 #ifdef HAVE_BAGL
     struct {

--- a/app/src/handle_swap.c
+++ b/app/src/handle_swap.c
@@ -75,10 +75,9 @@ swap_handle_check_address(check_address_parameters_t *params)
 
     TZ_CHECK(read_bip32_path(&bip32_path, params->address_parameters,
                              params->address_parameters_length));
-
-    TZ_CHECK(
-        derive_pkh(derivation_type, &bip32_path, address, sizeof(address)));
-
+    cx_ecfp_public_key_t pubkey;
+    TZ_CHECK(derive_pk(&pubkey, derivation_type, &bip32_path));
+    TZ_CHECK(derive_pkh(&pubkey, derivation_type, address, sizeof(address)));
     if (strcmp(params->address_to_check, address) != 0) {
         PRINTF("[ERROR] Check address fail: %s !=  %s\n",
                params->address_to_check, address);
@@ -213,8 +212,9 @@ error:
 void
 swap_check_validity(void)
 {
-    tz_operation_state *op = &global.apdu.sign.u.clear.parser_state.operation;
-    char                dstaddr[ADDRESS_MAX_SIZE];
+    tz_operation_state *op
+        = &global.keys.apdu.sign.u.clear.parser_state.operation;
+    char dstaddr[ADDRESS_MAX_SIZE];
     TZ_PREAMBLE((""));
 
     if (!G_called_from_swap)

--- a/app/src/keys.c
+++ b/app/src/keys.c
@@ -94,16 +94,13 @@ derive_pk(cx_ecfp_public_key_t *public_key, derivation_type_t derivation_type,
 }
 
 void
-derive_pkh(derivation_type_t derivation_type, const bip32_path_t *bip32_path,
+derive_pkh(cx_ecfp_public_key_t *pubkey, derivation_type_t derivation_type,
            char *buffer, size_t len)
 {
-    cx_ecfp_public_key_t pubkey = {0};
-    uint8_t              hash[21];
+    uint8_t hash[21];
     TZ_PREAMBLE(("buffer=%p, len=%u", buffer, len));
-
     TZ_ASSERT_NOTNULL(buffer);
-    TZ_CHECK(derive_pk(&pubkey, derivation_type, bip32_path));
-    TZ_CHECK(public_key_hash(hash + 1, 20, NULL, derivation_type, &pubkey));
+    TZ_CHECK(public_key_hash(hash + 1, 20, NULL, derivation_type, pubkey));
     // clang-format off
     switch (derivation_type) {
     case DERIVATION_TYPE_SECP256K1: hash[0] = 1; break;

--- a/app/src/keys.h
+++ b/app/src/keys.h
@@ -57,7 +57,7 @@ typedef struct {
 void read_bip32_path(bip32_path_t *, const uint8_t *, size_t);
 void derive_pk(cx_ecfp_public_key_t *, derivation_type_t,
                const bip32_path_t *);
-void derive_pkh(derivation_type_t, const bip32_path_t *, char *, size_t);
+void derive_pkh(cx_ecfp_public_key_t *, derivation_type_t, char *, size_t);
 void sign(derivation_type_t, const bip32_path_t *, const uint8_t *, size_t,
           uint8_t *, size_t *);
 

--- a/app/src/ui_stream_nbgl.c
+++ b/app/src/ui_stream_nbgl.c
@@ -56,8 +56,8 @@ tz_reject(void)
     FUNC_ENTER(("void"));
 
     // Stax can reject early
-    global.apdu.sign.step              = SIGN_ST_WAIT_USER_INPUT;
-    global.apdu.sign.received_last_msg = true;
+    global.keys.apdu.sign.step              = SIGN_ST_WAIT_USER_INPUT;
+    global.keys.apdu.sign.received_last_msg = true;
 
     s->cb(TZ_UI_STREAM_CB_REJECT);
 
@@ -85,7 +85,7 @@ tz_accept_ui(void)
 
     FUNC_ENTER(("void"));
 
-    global.apdu.sign.step = SIGN_ST_WAIT_USER_INPUT;
+    global.keys.apdu.sign.step = SIGN_ST_WAIT_USER_INPUT;
     s->cb(TZ_UI_STREAM_CB_ACCEPT);
 
     nbgl_useCaseStatus("SIGNING\nSUCCESSFUL", true, ui_home_init);
@@ -218,7 +218,7 @@ tz_ui_stream_close(void)
     }
     s->full = true;
 
-    if (global.apdu.sign.u.clear.skip_to_sign) {
+    if (global.keys.apdu.sign.u.clear.skip_to_sign) {
         tz_ui_stream();
     }
 
@@ -245,7 +245,7 @@ tz_ui_nav_cb(uint8_t page, nbgl_pageContent_t *content)
     if (page == LAST_PAGE_FOR_REVIEW) {
         // skipped
         PRINTF("Skip requested");
-        global.apdu.sign.u.clear.skip_to_sign = true;
+        global.keys.apdu.sign.u.clear.skip_to_sign = true;
         tz_ui_continue();
     }
 

--- a/tests/integration/nano/test_provide_tz1_bip25519_pk.sh
+++ b/tests/integration/nano/test_provide_tz1_bip25519_pk.sh
@@ -8,5 +8,5 @@ TIMEOUT=80 expect_section_content "Provide Key" 'tz1VKyZ3RFDwTkrz5LKcTc6fcYqZj6p
 press_button right
 expected_accept_public_key
 press_button both
-TIMEOUT=100 expect_apdu_return 210293c6b359964a4332bf1355579d665b753343f7b0a42567978cea1671f7b89f479000
+expect_apdu_return 210293c6b359964a4332bf1355579d665b753343f7b0a42567978cea1671f7b89f479000
 quit_app


### PR DESCRIPTION
fixes #108. 
Add pk to globals to save repeated computation of pk. added pub key to global.key in union with apdu as apdu.hash/sign is not used concurrently with pk in any operation.