### PR TITLE
ui_strings: a ring buffer for screen text

### DIFF
--- a/app/src/exception.h
+++ b/app/src/exception.h
@@ -20,8 +20,8 @@
 
 #pragma once
 
-#include <os.h>
 #include <io.h>
+#include <os.h>
 
 #define SW_OK 0x9000
 

--- a/app/src/globals.h
+++ b/app/src/globals.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include <memory.h>
+#include <string.h>
 #include <bolos_target.h>
 
 #define TZ_SCREEN_WITDH_FULL_REGULAR_11PX       19

--- a/app/src/globals.h
+++ b/app/src/globals.h
@@ -92,8 +92,6 @@ typedef struct {
 #ifdef HAVE_BAGL
     struct {
         bagl_element_t bagls[5 + TZ_SCREEN_LINES_11PX];
-        char           lines[TZ_SCREEN_LINES_11PX]
-                  [TZ_SCREEN_WITDH_FULL_REGULAR_11PX + 1];
     } ux;
 #endif
 #ifdef HAVE_NBGL

--- a/app/src/ui_stream.c
+++ b/app/src/ui_stream.c
@@ -18,6 +18,7 @@
 
 #include "globals.h"
 #include "exception.h"
+#include "ui_strings.h"
 
 /* Prototypes */
 

--- a/app/src/ui_stream.c
+++ b/app/src/ui_stream.c
@@ -34,6 +34,9 @@ static void         redisplay(void);
 const bagl_icon_details_t C_icon_rien = {0, 0, 1, NULL, NULL};
 #endif  // HAVE_BAGL
 
+static void drop_last_screen(void);
+static void push_str(const char *, size_t, char **);
+
 // Model
 
 #ifdef HAVE_BAGL
@@ -48,6 +51,10 @@ tz_ui_stream_init(void (*cb)(uint8_t))
     s->full    = false;
     s->current = 0;
     s->total   = -1;
+    s->last    = 0;
+
+    ui_strings_init();
+
     FUNC_LEAVE();
 }
 #endif
@@ -130,7 +137,6 @@ tz_ui_stream_pushl(tz_ui_cb_type_t cb_type, const char *title,
                    tz_ui_layout_type_t layout_type, tz_ui_icon_t icon)
 {
     tz_ui_stream_t *s = &global.stream;
-    size_t          i;
 
     FUNC_ENTER(("title=%s, value=%s", title, value));
     if (s->full) {
@@ -140,14 +146,24 @@ tz_ui_stream_pushl(tz_ui_cb_type_t cb_type, const char *title,
 #ifdef TEZOS_DEBUG
     int prev_total   = s->total;
     int prev_current = s->current;
+    int prev_last    = s->last;
 #endif
 
     s->total++;
     int bucket = s->total % TZ_UI_STREAM_HISTORY_SCREENS;
 
-    STRLCPY(s->screens[bucket].title, title);
-    for (i = 0; i < TZ_UI_STREAM_CONTENTS_LINES; i++)
-        s->screens[bucket].body[i][0] = '\0';
+    if (s->total >= 0
+        && (s->current % TZ_UI_STREAM_HISTORY_SCREENS) == bucket) {
+        PRINTF(
+            "[ERROR] PANIC!!!! Overwriting current screen, some bad things "
+            "are happening\n");
+    }
+
+    /* drop the previous screen text in our bucket */
+    if (s->total > 0 && bucket == (s->last % TZ_UI_STREAM_HISTORY_SCREENS))
+        drop_last_screen();
+
+    push_str(title, strlen(title), &s->screens[bucket].title);
 
     // Ensure things fit on one line
     size_t length = strlen(value);
@@ -174,7 +190,7 @@ tz_ui_stream_pushl(tz_ui_cb_type_t cb_type, const char *title,
             "offset: %d)\n",
             &value[offset], will_fit, line, offset);
 
-        strlcpy(s->screens[bucket].body[line], &value[offset], will_fit + 1);
+        push_str(&value[offset], will_fit, &s->screens[bucket].body[line]);
 
         offset += will_fit;
 
@@ -185,10 +201,15 @@ tz_ui_stream_pushl(tz_ui_cb_type_t cb_type, const char *title,
     PRINTF("[DEBUG]        bucket     %d\n", bucket);
     PRINTF("[DEBUG]        title:     \"%s\"\n", s->screens[bucket].title);
     for (line = 0; line < TZ_UI_STREAM_CONTENTS_LINES; line++)
-        PRINTF("[DEBUG]        value[%d]: \"%s\"\n", line,
-               s->screens[bucket].body[line]);
+        if (s->screens[bucket].body[line]) {
+            PRINTF("[DEBUG]        value[%d]:  \"%s\"\n", line,
+                   s->screens[bucket].body[line]);
+        } else {
+            PRINTF("[DEBUG]        value[%d]:  \"\"\n", line);
+        }
     PRINTF("[DEBUG]        total:     %d -> %d\n", prev_total, s->total);
     PRINTF("[DEBUG]        current:   %d -> %d\n", prev_current, s->current);
+    PRINTF("[DEBUG]        last:      %d -> %d\n", prev_last, s->last);
     PRINTF("[DEBUG]        offset:    %d\n", offset);
     FUNC_LEAVE();
 
@@ -211,8 +232,7 @@ pred(void)
     tz_ui_stream_t *s = &global.stream;
 
     FUNC_ENTER(("void"));
-    if (s->current >= 1
-        && s->current >= s->total - TZ_UI_STREAM_HISTORY_SCREENS + 2) {
+    if (s->current >= 1 && s->current > s->last) {
         s->current--;
     }
     FUNC_LEAVE();
@@ -287,6 +307,13 @@ find_icon(tz_ui_icon_t icon)
 static void
 redisplay_bnp(void)
 {
+    tz_ui_stream_t *s = &global.stream;
+    size_t          bucket;
+
+    FUNC_ENTER(("void"));
+
+    bucket = s->current % TZ_UI_STREAM_HISTORY_SCREENS;
+
     bagl_element_t init[] = {
   //  {type, userid, x, y, width, height, stroke, radius,
   //   fill, fgcolor, bgcolor, font_id, icon_id}, text/icon
@@ -301,52 +328,37 @@ redisplay_bnp(void)
          (const char *)&C_icon_rien},
         {{BAGL_LABELINE, 0x02, 8, 8, 112, 11, 0, 0, 0, 0xFFFFFF, 0x000000,
           BOLD, 0},
-         global.ux.lines[0]        },
+         s->screens[bucket].title  },
 #ifdef TARGET_NANOS
         {{BAGL_LABELINE, 0x02, 0, 19, 128, 11, 0, 0, 0, 0xFFFFFF, 0x000000,
           REGULAR, 0},
-         global.ux.lines[1]        },
+         s->screens[bucket].body[0]},
         {{BAGL_ICON, 0x00, 56, 14, 16, 16, 0, 0, 0, 0xFFFFFF, 0x000000, 0,
           BAGL_GLYPH_NOGLYPH},
          (const char *)&C_icon_rien},
 #else
         {{BAGL_LABELINE, 0x02, 0, 21, 128, 11, 0, 0, 0, 0xFFFFFF, 0x000000,
           REGULAR, 0},
-         global.ux.lines[1]},
+         s->screens[bucket].body[0]},
         {{BAGL_LABELINE, 0x02, 0, 34, 128, 11, 0, 0, 0, 0xFFFFFF, 0x000000,
           REGULAR, 0},
-         global.ux.lines[2]},
+         s->screens[bucket].body[1]},
         {{BAGL_LABELINE, 0x02, 0, 47, 128, 11, 0, 0, 0, 0xFFFFFF, 0x000000,
           REGULAR, 0},
-         global.ux.lines[3]},
+         s->screens[bucket].body[2]},
         {{BAGL_LABELINE, 0x02, 0, 60, 128, 11, 0, 0, 0, 0xFFFFFF, 0x000000,
           REGULAR, 0},
-         global.ux.lines[4]},
+         s->screens[bucket].body[3]},
         {{BAGL_ICON, 0x00, 56, 47, 16, 16, 0, 0, 0, 0xFFFFFF, 0x000000, 0,
           BAGL_GLYPH_NOGLYPH},
          (const char *)&C_icon_rien},
 #endif
     };
 
-    tz_ui_stream_t *s = &global.stream;
-    size_t          bucket, i;
-
-    FUNC_ENTER(("void"));
-
-    for (i = 0; i < TZ_SCREEN_LINES_11PX; i++)
-        global.ux.lines[i][0] = 0;
-
-    bucket = s->current % TZ_UI_STREAM_HISTORY_SCREENS;
-
-    STRLCPY(global.ux.lines[0], s->screens[bucket].title);
-    for (i = 0; i < TZ_UI_STREAM_CONTENTS_LINES; i++) {
-        STRLCPY(global.ux.lines[i + 1], s->screens[bucket].body[i]);
-    }
-
     tz_ui_icon_t icon = s->screens[bucket].icon;
     if (icon) {
 #ifdef TARGET_NANOS
-        global.ux.lines[1][0] = 0;
+        init[sizeof(init) / sizeof(bagl_element_t) - 2].text = NULL;
 #endif
         init[sizeof(init) / sizeof(bagl_element_t) - 1].text
             = find_icon(icon);
@@ -371,6 +383,13 @@ redisplay_bnp(void)
 static void
 redisplay_bp(void)
 {
+    tz_ui_stream_t *s = &global.stream;
+    size_t          bucket;
+
+    FUNC_ENTER(("void"));
+
+    bucket = s->current % TZ_UI_STREAM_HISTORY_SCREENS;
+
     bagl_element_t init[] = {
   //  {type, userid, x, y, width, height, stroke, radius,
   //   fill, fgcolor, bgcolor, font_id, icon_id}, text/icon
@@ -385,52 +404,37 @@ redisplay_bp(void)
          (const char *)&C_icon_rien},
         {{BAGL_LABELINE, 0x02, 8, 8, 112, 11, 0, 0, 0, 0xFFFFFF, 0x000000,
           BOLD, 0},
-         global.ux.lines[0]        },
+         s->screens[bucket].title  },
 #ifdef TARGET_NANOS
         {{BAGL_LABELINE, 0x02, 0, 19, 128, 11, 0, 0, 0, 0xFFFFFF, 0x000000,
           BOLD, 0},
-         global.ux.lines[1]        },
+         s->screens[bucket].body[0]},
         {{BAGL_ICON, 0x00, 56, 14, 16, 16, 0, 0, 0, 0xFFFFFF, 0x000000, 0,
           BAGL_GLYPH_NOGLYPH},
          (const char *)&C_icon_rien},
 #else
         {{BAGL_LABELINE, 0x02, 0, 21, 128, 11, 0, 0, 0, 0xFFFFFF, 0x000000,
           BOLD, 0},
-         global.ux.lines[1]},
+         s->screens[bucket].body[0]},
         {{BAGL_LABELINE, 0x02, 0, 34, 128, 11, 0, 0, 0, 0xFFFFFF, 0x000000,
           BOLD, 0},
-         global.ux.lines[2]},
+         s->screens[bucket].body[1]},
         {{BAGL_LABELINE, 0x02, 0, 47, 128, 11, 0, 0, 0, 0xFFFFFF, 0x000000,
           BOLD, 0},
-         global.ux.lines[3]},
+         s->screens[bucket].body[2]},
         {{BAGL_LABELINE, 0x02, 0, 60, 128, 11, 0, 0, 0, 0xFFFFFF, 0x000000,
           BOLD, 0},
-         global.ux.lines[4]},
+         s->screens[bucket].body[3]},
         {{BAGL_ICON, 0x00, 56, 47, 16, 16, 0, 0, 0, 0xFFFFFF, 0x000000, 0,
           BAGL_GLYPH_NOGLYPH},
          (const char *)&C_icon_rien},
 #endif
     };
 
-    tz_ui_stream_t *s = &global.stream;
-    size_t          bucket, i;
-
-    FUNC_ENTER(("void"));
-
-    for (i = 0; i < TZ_SCREEN_LINES_11PX; i++)
-        global.ux.lines[i][0] = 0;
-
-    bucket = s->current % TZ_UI_STREAM_HISTORY_SCREENS;
-
-    STRLCPY(global.ux.lines[0], s->screens[bucket].title);
-    for (i = 0; i < TZ_UI_STREAM_CONTENTS_LINES; i++) {
-        STRLCPY(global.ux.lines[i + 1], s->screens[bucket].body[i]);
-    }
-
     tz_ui_icon_t icon = s->screens[bucket].icon;
     if (icon) {
 #ifdef TARGET_NANOS
-        global.ux.lines[1][0] = 0;
+        init[sizeof(init) / sizeof(bagl_element_t) - 2].text = NULL;
 #endif
         init[sizeof(init) / sizeof(bagl_element_t) - 1].text
             = find_icon(icon);
@@ -439,7 +443,7 @@ redisplay_bp(void)
     /* If we aren't on the first screen, we can go back */
     if (s->current > 0) {
         /* Unless we can't... */
-        if (s->current == s->total - TZ_UI_STREAM_HISTORY_SCREENS + 1)
+        if (s->current == s->last)
             init[1].text = (const char *)&C_icon_go_forbid;
         else
             init[1].text = (const char *)&C_icon_go_left;
@@ -531,3 +535,48 @@ tz_ui_stream(void)
     FUNC_LEAVE();
 }
 #endif
+
+void
+drop_last_screen(void)
+{
+    tz_ui_stream_t *s      = &global.stream;
+    size_t          bucket = s->last % TZ_UI_STREAM_HISTORY_SCREENS;
+    size_t          i;
+
+    TZ_PREAMBLE(("last: %d", s->last));
+
+    if (s->screens[bucket].title)
+        TZ_CHECK(ui_strings_drop(&s->screens[bucket].title));
+    for (i = 0; i < TZ_UI_STREAM_CONTENTS_LINES; i++) {
+        if (s->screens[bucket].body[i]) {
+            TZ_CHECK(ui_strings_drop(&s->screens[bucket].body[i]));
+        }
+    }
+
+    s->last++;
+
+    TZ_POSTAMBLE;
+}
+
+void
+push_str(const char *text, size_t len, char **out)
+{
+    bool can_fit = false;
+
+    TZ_PREAMBLE(("%s", text));
+
+    if (len == 0) {
+        *out = NULL;
+        TZ_SUCCEED();
+    }
+
+    TZ_CHECK(ui_strings_can_fit(len, &can_fit));
+    while (!can_fit) {
+        TZ_CHECK(drop_last_screen());
+        TZ_CHECK(ui_strings_can_fit(len, &can_fit));
+    }
+
+    TZ_CHECK(ui_strings_push(text, len, out));
+
+    TZ_POSTAMBLE;
+}

--- a/app/src/ui_stream.h
+++ b/app/src/ui_stream.h
@@ -43,6 +43,8 @@
 
 #include <stdbool.h>
 
+#include "ui_strings.h"
+
 #ifdef TARGET_NANOS
 #define TZ_UI_STREAM_HISTORY_SCREENS 5
 #else
@@ -113,8 +115,8 @@ typedef struct {
     tz_ui_icon_t        icon;
     tz_ui_layout_type_t layout_type;
     tz_ui_cb_type_t     cb_type;
-    char                title[TZ_UI_STREAM_TITLE_WIDTH + 1];
-    char body[TZ_UI_STREAM_CONTENTS_LINES][TZ_UI_STREAM_CONTENTS_WIDTH + 1];
+    char               *title;
+    char               *body[TZ_UI_STREAM_CONTENTS_LINES];
 } tz_ui_stream_screen_t;
 
 #ifdef HAVE_NBGL
@@ -129,8 +131,10 @@ typedef struct {
 typedef struct {
     void (*cb)(tz_ui_cb_type_t);
     tz_ui_stream_screen_t screens[TZ_UI_STREAM_HISTORY_SCREENS];
+    tz_ui_strings_t       strings;
     int16_t               current;
     int16_t               total;
+    int16_t               last;
     bool                  full;
     // FIXME: workaround for issue with non-local control flow. Remove once
     // fixed see !66

--- a/app/src/ui_stream_nbgl.c
+++ b/app/src/ui_stream_nbgl.c
@@ -166,8 +166,11 @@ tz_ui_stream_init(void (*cb)(uint8_t))
     memset(s, 0x0, sizeof(*s));
     s->cb      = cb;
     s->full    = false;
+    s->last    = 0;
     s->current = -1;
     s->total   = -1;
+
+    ui_strings_init();
 
     nbgl_useCaseReviewStart(&C_tezos, "Review request to sign operation",
                             NULL, "Reject request", tz_ui_review_start,

--- a/app/src/ui_strings.c
+++ b/app/src/ui_strings.c
@@ -1,0 +1,330 @@
+/* Tezos Ledger application - Generic stream display
+
+   Copyright 2023 TriliTech <contact@trili.tech>
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <io.h>
+#include <stdbool.h>
+
+#include "globals.h"
+#include "ui_strings.h"
+
+/* Allow future unit tests to override */
+#ifndef UI_STRINGS
+static tz_ui_strings_t ui_strings;
+#define UI_STRINGS &ui_strings
+#endif
+
+#define BUFF_START ((char *)(s->buffer))
+#define BUFF_END   ((char *)(s->buffer) + BUFF_LEN)
+
+/* Prototypes */
+void   ui_strings_init(void);
+void   ui_strings_push(const char *str, size_t len, char **out);
+void   ui_strings_drop(char **str);
+size_t ui_strings_fit_up_to(size_t len, char **write_start);
+void   ui_strings_can_fit(size_t len, bool *can_fit);
+bool   ui_strings_is_empty();
+
+#ifdef TEZOS_DEBUG
+void ui_strings_print();
+#define PRINT_STRINGS ui_strings_print()
+#else
+#define PRINT_STRINGS
+#endif
+
+/* Definitions */
+void
+ui_strings_init(void)
+{
+    tz_ui_strings_t *s = UI_STRINGS;
+
+    memset(s->buffer, '\0', BUFF_LEN);
+    s->start        = BUFF_START;
+    s->end          = BUFF_START;
+    s->internal_end = BUFF_START;
+    s->count        = 0;
+}
+
+/* @param len: we want to a string s of strlen(s) == len
+   @param write_start: this is where we'll start writing this string in the
+   buffer
+   @return out_len: this is the length of the string we can fit. out_len <=
+   len
+*/
+size_t
+ui_strings_fit_up_to(size_t len, char **write_start)
+{
+    tz_ui_strings_t *s       = UI_STRINGS;
+    size_t           out_len = 0;
+    TZ_PREAMBLE(
+        ("len=%d, start=%p, end=%p", len, s->start, s->end, s->internal_end));
+    PRINT_STRINGS;
+
+    /* Preconditions */
+    TZ_ASSERT(EXC_MEMORY_ERROR, (*write_start == NULL));
+    TZ_ASSERT(EXC_MEMORY_ERROR, (len > 0));
+    /* Internal checks */
+    TZ_ASSERT(EXC_MEMORY_ERROR, (s->end <= s->internal_end));
+
+    if (ui_strings_is_empty()) {
+        TZ_ASSERT(EXC_MEMORY_ERROR, (len < BUFF_LEN));
+
+        *write_start = s->start;
+        out_len      = len;
+
+        TZ_SUCCEED();
+    }
+
+    /* Buffer not empty */
+
+    if (s->start > s->end) {
+        *write_start = s->end;
+        out_len      = MIN((size_t)(s->start - 1 - s->end), len);
+    } else if (s->start < s->end) {
+        /* start < end */
+        size_t chars_at_start = MIN((size_t)(s->start - BUFF_START), len + 1);
+        chars_at_start
+            = chars_at_start > 0 ? chars_at_start - 1 : chars_at_start;
+
+        size_t chars_at_end = MIN((size_t)(BUFF_END - s->end), len + 1);
+        chars_at_end = chars_at_end > 0 ? chars_at_end - 1 : chars_at_end;
+
+        if (chars_at_end == len || chars_at_end >= chars_at_start) {
+            *write_start = s->end;
+            out_len      = chars_at_end;
+        } else {
+            *write_start = BUFF_START;
+            out_len      = chars_at_start;
+        }
+    }
+
+    TZ_POSTAMBLE;
+    PRINTF("[DEBUG] ws=%p out_len=%d\n", *write_start, out_len);
+    return out_len;
+}
+
+void
+ui_strings_can_fit(size_t len, bool *can_fit)
+{
+    char  *ws = NULL;
+    size_t out_len;
+
+    TZ_PREAMBLE(("len=%d", len));
+
+    TZ_CHECK(out_len = ui_strings_fit_up_to(len, &ws));
+
+    *can_fit = (out_len == len);
+
+    TZ_POSTAMBLE;
+}
+
+/* @param in: ptr to char[] to copy into the buffer
+   @param in_len: number of of chars to copy. in_len <= strlen(in)
+   @param out: will be set to the start of the char[] in the buffer
+
+   // TODO: for future, when appending is a possibility
+   @param out_len: strlen(out) 0 < out_len <= in_len
+*/
+void
+ui_strings_push(const char *in, size_t len, char **out)
+{
+    tz_ui_strings_t *s = UI_STRINGS;
+    TZ_PREAMBLE(("'%s' | in=%p, len=%d, start=%p, end=%p, internal_end=%p",
+                 in, in, len, s->start, s->end, s->internal_end));
+    PRINT_STRINGS;
+
+    /* Preconditions */
+    TZ_ASSERT(EXC_MEMORY_ERROR, (*out == NULL));
+    TZ_ASSERT_NOTNULL(in);
+    TZ_ASSERT(EXC_MEMORY_ERROR, (len > 0));
+    /* Internal checks */
+    TZ_ASSERT(EXC_MEMORY_ERROR, (s->end <= s->internal_end));
+
+    char  *ws = NULL;
+    size_t out_len;
+    TZ_CHECK(out_len = ui_strings_fit_up_to(len, &ws));
+    PRINTF("[DEBUG] Found space from %p to %p (for %d chars)\n", ws,
+           ws + out_len, out_len);
+
+    TZ_ASSERT(EXC_MEMORY_ERROR, (out_len == len));
+
+    strlcpy(ws, in, len + 1);
+    s->count++;
+
+    s->end = ws + len + 1;
+
+    if (s->end > s->internal_end)
+        s->internal_end = s->end;
+
+    *out = ws;
+    PRINTF("[DEBUG] Pushed '%s' to %p\n", *out, *out);
+
+    TZ_POSTAMBLE;
+    PRINT_STRINGS;
+}
+
+void
+ui_strings_drop(char **in)
+{
+    tz_ui_strings_t *s = UI_STRINGS;
+    TZ_PREAMBLE(("in=%p, start=%p, end=%p", *in, s->start, s->end));
+    PRINT_STRINGS;
+
+    /* argument checks */
+    TZ_ASSERT(EXC_MEMORY_ERROR, (*in == s->start));
+    TZ_ASSERT(EXC_MEMORY_ERROR, (!ui_strings_is_empty()));
+    /* Internal checks */
+    TZ_ASSERT(EXC_MEMORY_ERROR, (s->start < s->internal_end));
+    TZ_ASSERT(EXC_MEMORY_ERROR, (s->end <= s->internal_end));
+
+    size_t len = strlen(*in);
+    TZ_ASSERT(EXC_MEMORY_ERROR, (len > 0));
+
+    char *new = *in + len + 1;
+    TZ_ASSERT(EXC_MEMORY_ERROR, (new <= s->internal_end));
+
+    PRINTF("[DEBUG] zeroing %p (%d) (%s)\n", s->start, len, s->start);
+    memset(s->start, '\0', len);
+    *in = NULL;
+    s->count--;
+
+    if (new < s->internal_end) {
+        TZ_ASSERT(EXC_MEMORY_ERROR, (*new != '\0'));
+        s->start = new;
+        TZ_SUCCEED();
+    }
+
+    /* This was the last string in the region */
+
+    s->start = BUFF_START;
+
+    if (s->end == s->internal_end) {
+        /* This was the last string in the ring buffer */
+        s->end = BUFF_START;
+        TZ_ASSERT(EXC_MEMORY_ERROR, (ui_strings_is_empty()));
+    }
+
+    s->internal_end = s->end;
+
+    TZ_POSTAMBLE;
+    PRINT_STRINGS;
+}
+
+bool
+ui_strings_is_empty()
+{
+    tz_ui_strings_t *s = UI_STRINGS;
+    return s->start == s->end && s->count == 0; /* check COUNT is zero! */
+}
+
+#ifdef TEZOS_DEBUG
+void
+ui_strings_next(char **p)
+{
+    tz_ui_strings_t *s = UI_STRINGS;
+
+    if (*p >= s->start) {
+        size_t len  = strlen(*p);
+        char  *next = *p + len + 1;
+
+        if (next < s->internal_end) {
+            *p = next;
+        } else if (s->start >= s->end) {
+            *p = BUFF_START;
+        } else {
+            *p = NULL;
+        }
+    } else if (*p < s->end) {
+        size_t len  = strlen(*p);
+        char  *next = *p + len + 1;
+
+        if (next < s->end) {
+            *p = next;
+        } else {
+            *p = NULL;
+        }
+    } else {
+        *p = NULL;
+    }
+}
+
+void
+ui_strings_print()
+{
+    tz_ui_strings_t *s = UI_STRINGS;
+
+    if (ui_strings_is_empty()) {
+        PRINTF("[DEBUG] START\t\t%p\n[DEBUG] END\t\t%p\n", BUFF_START,
+               BUFF_END);
+        return;
+    }
+
+    if (s->start == BUFF_START) {
+        char *p = s->start;
+        PRINTF("[DEBUG] START\tstart->\t%p %s\n", s->start, s->start);
+        while (true) {
+            ui_strings_next(&p);
+            if (!p)
+                break;
+            PRINTF("[DEBUG] \t\t%p %s\n", p, p);
+        }
+        if (s->end < BUFF_END) {
+            PRINTF("[DEBUG] \tend  ->\t%p\n[DEBUG] END\t\t%p\n", s->end,
+                   BUFF_END);
+        } else {
+            PRINTF("[DEBUG] END\tend ->\t%p\n", s->end);
+        }
+    } else if (s->start >= s->end) {
+        char *p = BUFF_START;
+        PRINTF("[DEBUG] START\t\t%p %s\n", p, p);
+        while (true) {
+            ui_strings_next(&p);
+
+            if (!p) {
+                PRINTF("[DEBUG] \tend  ->\t%p\n", s->end);
+                break;
+            }
+            PRINTF("[DEBUG] \t\t%p %s\n", p, p);
+        }
+
+        p = s->start;
+        PRINTF("[DEBUG] \tstart->\t%p %s\n", p, p);
+        while (true) {
+            ui_strings_next(&p);
+            if (p >= s->start)
+                PRINTF("[DEBUG] \t\t%p %s\n", p, p);
+            else
+                break;
+        }
+        PRINTF("[DEBUG] END\t\t%p\n", BUFF_END);
+    } else {
+        char *p = s->start;
+        PRINTF("[DEBUG] START\t\t%p\n", BUFF_START);
+        PRINTF("[DEBUG] \tstart->\t%p %s\n", p, p);
+        while (true) {
+            ui_strings_next(&p);
+            if (!p)
+                break;
+            PRINTF("[DEBUG] \t\t%p %s\n", p, p);
+        }
+        if (s->end < BUFF_END) {
+            PRINTF("[DEBUG] \tend  ->\t%p\n[DEBUG] END\t\t%p\n", s->end,
+                   BUFF_END);
+        } else {
+            PRINTF("[DEBUG] END\tend ->\t%p\n", s->end);
+        }
+    }
+}
+#endif

--- a/app/src/ui_strings.h
+++ b/app/src/ui_strings.h
@@ -1,0 +1,50 @@
+/* Tezos Ledger application - Dynamic UI to display a stream of pages
+
+   Copyright 2023 TriliTech <contact@trili.tech>
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#pragma once
+
+/* This implements a multi-page screen, allowing to display a
+   potentially infinite number of screens, keeping a bounded history.
+   The user can query new screens using the right button, and go back
+   a few screens using the left button (until history limit is
+   reached).
+
+   When a new page is needed, the display will call the `refill`
+   callback, which in turn can call `tz_ui_stream_push` to add a new
+   page. When the last page is reached, `tz_ui_stream_close` should be
+   called, and the two final special pages to `accept` and `reject`
+   the operation are pushed. The user can trigger the `accept` and
+   `reject` callbacks by pressing both buttons while there pages are
+   displayed.
+
+   It is also possible to use this display engine for non streamed
+   data by pushing a precomputed series of pages with
+   `tz_ui_stream_push`, calling `tz_ui_stream_close`, and launching
+   with a `refill` callback set to NULL. */
+
+#define BUFF_LEN 128
+typedef struct {
+    char   buffer[BUFF_LEN];
+    char  *start;
+    char  *end;
+    char  *internal_end;
+    size_t count;
+} tz_ui_strings_t;
+
+void ui_strings_init(void);
+void ui_strings_push(const char *, size_t, char **);
+void ui_strings_drop(char **);
+void ui_strings_can_fit(size_t, bool *);

--- a/app/src/ui_strings.h
+++ b/app/src/ui_strings.h
@@ -35,7 +35,12 @@
    `tz_ui_stream_push`, calling `tz_ui_stream_close`, and launching
    with a `refill` callback set to NULL. */
 
+#ifdef TARGET_NANOS
 #define BUFF_LEN 128
+#else
+#define BUFF_LEN 256
+#endif
+
 typedef struct {
     char   buffer[BUFF_LEN];
     char  *start;


### PR DESCRIPTION
progress towards:
- #91 
- #23 

# Context
We are trying to update STAX to allow multiple values per screen. Doing so in the same method  as `ui_stream.c` would be very wasteful though - as stax values could be _up to_ well over 120+ bytes per value on a single screen, but most of the time we don't need anything close to that (e.g. `Fee` field etc).

Therefore, we compress all strings in memory, into a 'sudo'-ring-buffer, to allow more efficient use memory, for screens (on all devices) that consume fewer bytes than are pre-allocated arrays in the `global.screens[bucket]`.

This actually results in a saving of well over 30bytes on the nanos, and with the current parameters, over 250-300bytes on the nanosp/x. It will theoretically save potential 1-2 kilobytes on the Stax, if we implement history there (we currently have 8 history screens there currently, so it already will save a lot of memory, but we don't currently make use of them).