### PR TITLE
ui_strings: global not static

### DIFF
--- a/app/src/ui_strings.c
+++ b/app/src/ui_strings.c
@@ -22,8 +22,7 @@
 
 /* Allow future unit tests to override */
 #ifndef UI_STRINGS
-static tz_ui_strings_t ui_strings;
-#define UI_STRINGS &ui_strings
+#define UI_STRINGS &global.stream.strings
 #endif
 
 #define BUFF_START ((char *)(s->buffer))


### PR DESCRIPTION
Left over from a bad rebase/commit shuffle.

The following now works:
```
make clean
make app_nanos_dbg.tgz
docker run --rm -it --entrypoint /bin/bash -v $(pwd):/app --network host ledger-app-tezos-integration-tests

cd /app
git config --global --add safe.directory /app
./tests/integration/nano/test_tz2_sign_micheline_basic.py --device nanos --port 5000 --display headless --vnc-port 41000 --app app/bin/app.elf
```