### PR TITLE
docker: more precise pinning of packages for building tests image

### DIFF
--- a/docker/Dockerfile.integration-tests
+++ b/docker/Dockerfile.integration-tests
@@ -1,10 +1,11 @@
 FROM ghcr.io/ledgerhq/speculos:sha-bced779
 
-RUN apt update &&                                               \
-    apt install -y curl jq build-essential libsodium-dev git xxd &&	\
-    pip install base58 pytezos pytesseract GitPython &&                   \
-    git clone --depth 1 --branch v1.11.4 https://github.com/ledgerHQ/ragger && \
-    cd ragger &&                                                \
+RUN apt update &&                                                                    \
+    apt install -y curl jq build-essential libsodium-dev git xxd &&                  \
+    pip install wheel setuptools pkginfo cryptography &&                             \
+    pip install jsonschema==4.3.2 base58 pytezos==3.10.2 GitPython &&                \
+    git clone --depth 1 --branch v1.11.4 https://github.com/ledgerHQ/ragger &&       \
+    cd ragger &&                                                                     \
     pip install --extra-index-url https://test.pypi.org/simple/ '.[all_backends]' && \
     cd ..
 


### PR DESCRIPTION
Failing to build currently due to timeout during dependency resolution.