### PR TITLE
stax: remove skip code

### DIFF
--- a/app/src/apdu_sign.h
+++ b/app/src/apdu_sign.h
@@ -58,7 +58,6 @@ typedef struct {
         struct {
             size_t          total_length;
             tz_parser_state parser_state;
-            bool            skip_to_sign;
             bool            received_msg;
         } clear;
         struct {

--- a/app/src/ui_stream_nbgl.c
+++ b/app/src/ui_stream_nbgl.c
@@ -188,10 +188,6 @@ tz_ui_stream_close(void)
     }
     s->full = true;
 
-    if (global.keys.apdu.sign.u.clear.skip_to_sign) {
-        tz_ui_stream();
-    }
-
     FUNC_LEAVE();
 }
 
@@ -222,15 +218,7 @@ tz_ui_nav_cb(uint8_t page, nbgl_pageContent_t *content)
         }
     }
 
-    if (page == LAST_PAGE_FOR_REVIEW) {
-        // skipped
-        global.keys.apdu.sign.u.clear.skip_to_sign = true;
-
-        nbgl_useCaseSpinner("Loading operation");
-        if (!s->full)
-            tz_ui_continue();
-
-    } else if (s->full && has_final_screen()) {
+    if (s->full && has_final_screen()) {
         s->total++;
     }
 

--- a/tests/integration/stax/utils.py
+++ b/tests/integration/stax/utils.py
@@ -147,15 +147,6 @@ class TezosAppScreen(metaclass=MetaScreen):
         else:
             self.welcome.client.finger_touch(BUTTON_LOWER_MIDDLE.x, BUTTON_LOWER_MIDDLE.y)
 
-    def review_skip_to_signing(self, with_loading=False):
-        self.review.client.finger_touch(BUTTON_LOWER_RIGHT.x, BUTTON_LOWER_RIGHT.y)
-        self.assert_screen("skip_to_signing")
-        self.review.client.pause_ticker()
-        self.review.client.finger_touch(BUTTON_ABOVE_LOWER_MIDDLE.x, BUTTON_ABOVE_LOWER_MIDDLE.y)
-        if with_loading: self.assert_screen("loading_operation")
-        self.review.client.resume_ticker()
-
-
 def stax_app(prefix) -> TezosAppScreen:
     port = os.environ["PORT"]
     commit = os.environ["COMMIT_BYTES"]


### PR DESCRIPTION
Previously, the skip button was removed. We now remove the remaining code related to that feature