### PR TITLE
CI: remove unneeded lines from reusable workflows

### DIFF
--- a/.github/workflows/guidelines_enforcer.yml
+++ b/.github/workflows/guidelines_enforcer.yml
@@ -21,5 +21,3 @@ jobs:
   guidelines_enforcer:
     name: Call Ledger guidelines_enforcer
     uses: LedgerHQ/ledger-app-workflows/.github/workflows/reusable_guidelines_enforcer.yml@v1
-    with:
-      relative_app_directory: app


### PR DESCRIPTION
Follow up suggestion from Ledger, the option will be deprecated at some point.

Related #149 