### PR TITLE
Reduce the global struct size

### DIFF
--- a/app/src/apdu_sign.h
+++ b/app/src/apdu_sign.h
@@ -74,8 +74,8 @@ typedef struct {
     union {
         /// @brief clear signing state info.
         struct {
-            size_t          total_length;
             tz_parser_state parser_state;
+            size_t          total_length;
             uint8_t         last_field_index;
             bool            received_msg;
         } clear;

--- a/app/src/globals.h
+++ b/app/src/globals.h
@@ -89,7 +89,6 @@ typedef enum {
  */
 typedef struct {
     /* State */
-    main_step_t             step;    /// Current operational state of app.
     tz_ui_stream_t          stream;  /// UX and display related information
     bip32_path_with_curve_t path_with_curve;  /// Derivation path
     union {
@@ -119,6 +118,7 @@ typedef struct {
     char error_code[ERROR_CODE_SIZE];  /// Error codes to be displayed in
                                        /// blindsigning.
 #endif
+    main_step_t step;  /// Current operational state of app.
 } globals_t;
 
 /* Settings */

--- a/app/src/parser/parser_state.h
+++ b/app/src/parser/parser_state.h
@@ -90,7 +90,6 @@ typedef struct {
     tz_parser_regs regs;  /// parser register
 
     /// common fields to communicate with caller
-    tz_parser_result errno;  /// current parser result
     struct {
         char field_name[TZ_FIELD_NAME_SIZE];  /// name of the last field
                                               /// parsed
@@ -100,14 +99,15 @@ typedef struct {
     } field_info;               /// information of the last field parsed
                                 // common singleton buffers
     int ofs;                    /// offset for the parser
+    /// input type specific state
+    tz_micheline_state micheline;  /// micheline parser state
+    tz_operation_state operation;  /// operation parser state
     struct {
         tz_num_parser_buffer num;                 /// number parser buffer
         uint8_t capture[TZ_CAPTURE_BUFFER_SIZE];  /// capture buffer is used
                                                   /// to store string values
     } buffers;
-    /// input type specific state
-    tz_micheline_state micheline;  /// micheline parser state
-    tz_operation_state operation;  /// operation parser state
+    tz_parser_result errno;  /// current parser result
 } tz_parser_state;
 
 /**

--- a/app/src/ui_stream.h
+++ b/app/src/ui_stream.h
@@ -139,12 +139,12 @@ typedef struct {
 #ifdef HAVE_BAGL
     tz_ui_icon_t icon;  /// Icon to display on the screen.
     tz_ui_layout_type_t
-        layout_type;  /// Layout type for the screen. CAN BP, BNP, NP, PB or
-                      /// HOME_X where X can be one of the BP, BNP, PB.
-    char *title;      /// Title to display on the screen.
-    char *body[TZ_UI_STREAM_CONTENTS_LINES];  /// Body to display on the
-                                              /// screen (Below title).
-    short body_len;  /// number of non-empty lines in the body.
+        layout_type;   /// Layout type for the screen. CAN BP, BNP, NP, PB or
+                       /// HOME_X where X can be one of the BP, BNP, PB.
+    uint8_t body_len;  /// number of non-empty lines in the body.
+    char   *title;     /// Title to display on the screen.
+    char   *body[TZ_UI_STREAM_CONTENTS_LINES];  /// Body to display on the
+                                                /// screen (Below title).
 #else
     nbgl_layoutTagValue_t
         pairs[NB_MAX_DISPLAYED_PAIRS_IN_REVIEW];  /// Title-value pairs to be

--- a/app/src/ui_strings.h
+++ b/app/src/ui_strings.h
@@ -27,7 +27,7 @@
  */
 
 #ifdef TARGET_NANOS
-#define BUFF_LEN 120  /// Ring buffer length of nanos
+#define BUFF_LEN 114  /// Ring buffer length of nanos
 #elif defined(HAVE_BAGL)
 #define BUFF_LEN 256  /// Ring buffer length for nanos2/nanox
 #else


### PR DESCRIPTION
At many times, when some fields were added on some structures, two tests were failing on **NanoS**:
 - `test_tz3_sign_micheline_basic`
 - `test_tz2_sign_micheline_basic.`
This is caused by an already known issue that signing with _tz2_ and _tz3_ needs more memory than for _tz1_.

This PR reduce the memory space required for the `global` by reordering structures fields.

Gain of `32*sizeof(uint8_t)` memory space.