### PR TITLE
Audit feedback fixes (v3.0.5)

### DIFF
--- a/app/src/apdu_sign.c
+++ b/app/src/apdu_sign.c
@@ -898,7 +898,7 @@ static void
 get_blindsign_type(char *type, size_t type_size)
 {
     TZ_PREAMBLE(("type=%s", type));
-    TZ_ASSERT(type_size >= OPERATION_TYPE_STR_LENGTH, EXC_MEMORY_ERROR);
+    TZ_ASSERT(EXC_MEMORY_ERROR, type_size >= OPERATION_TYPE_STR_LENGTH);
     // clang-format off
     switch (global.keys.apdu.sign.tag) {
     case 0x01:

--- a/app/src/format.h
+++ b/app/src/format.h
@@ -18,8 +18,17 @@
    See the License for the specific language governing permissions and
    limitations under the License. */
 
+#pragma once
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
 
+/**
+ * @brief Prints mutez as XTZ
+ *
+ * @param obuf: output buffer
+ * @param olen: length of the output buffer
+ * @param amount: amount in mutez
+ * @return bool: true on success
+ */
 bool tz_mutez_to_string(char *obuf, size_t olen, uint64_t amount);


### PR DESCRIPTION
Some feedbacks from Ledger's audit warn for some fixes/improvements:

 - A wrong assertion in the `get_blindsign_type` function
 - A missing header guard to the `format.h` file